### PR TITLE
Adding in input_Ea_units to the simulation settings and to canteraSimulate

### DIFF
--- a/PEUQSE/simulationDriver_YAML/canteraSimulate.py
+++ b/PEUQSE/simulationDriver_YAML/canteraSimulate.py
@@ -285,7 +285,7 @@ def simulatePFRorTPRwithCantera(model_name, canteraGasPhaseObject, canteraSurfac
             surf.TP = T_surf, P_gas
             if simulation_settings_module.piecewise_coverage_dependence == True:
                 modified_reactions_parameters_array = canteraKineticsParametersParser.calculatePiecewiseCoverageDependentModifiedParametersArray(simulation_settings_module, surf.species_names, surf.coverages) #This feature requires the piecewise coverage dependence settings AND the reactions_parameters_array to already be inside the surf object **in advance** #As of May 2022, this feature adds the E modifiers to Ea, and multiplies the pre-exponentials by 10**modifier.
-                canteraKineticsParametersParser.modifyReactionsInOnePhase(surf, modified_reactions_parameters_array, ArrheniusOnly=False) #May 20th 2022, changed the "ArrheniusOnly=True" to "ArrheniusOnly=False" during the YAML upgrade. 
+                canteraKineticsParametersParser.modifyReactionsInOnePhase(surf, modified_reactions_parameters_array, ArrheniusOnly=False, input_Ea_units = simulation_settings_module.input_Ea_units) #May 20th 2022, changed the "ArrheniusOnly=True" to "ArrheniusOnly=False" during the YAML upgrade. 
             surf.advance_coverages(t_step_size)  #sim.advance(time) would not work. Changing T with time is not officially supported but happens to work with surf.advance_coverages. Supported way to change temperature during simulation for arbitrary reactors is to use custom integrator: https://cantera.org/examples/python/reactors/custom.py.html
             dist = 0.0
             sim_dist.append(dist)

--- a/PEUQSE/simulationDriver_YAML/ceO2_input_simulation_settings.py
+++ b/PEUQSE/simulationDriver_YAML/ceO2_input_simulation_settings.py
@@ -4,6 +4,7 @@ minute = 60.0 #This will convert things to seconds, as required by cantera.
 atm = 101325.0 #This will convert atm to Pascal, as requred by cantera
 
 '''START OF settings that users should change.'''
+input_Ea_units = 'J/kmol' #currently, the supported options are 'J/kmol' (cantera default) or 'J/mol'
 flow_type = "Static" #can be "PFR" or "Static". It does not only affect the next line, it affects the simulation.
 T_gas_feed = 300 
 T_surf = 100 #Initial temperature in K.


### PR DESCRIPTION
Adding in input_Ea_units to the simulation settings and to canteraSimulate
adding in the place to use the units, and then using them. This should only affect the Example 5 outputs. Note: it looks like the example 5 case was (until now) using J/kmol unintentionally.